### PR TITLE
Update of financial assistance and DSA test end time

### DIFF
--- a/_admissions/Year 1 and 3 Admissions/Year 1 Admissions.md
+++ b/_admissions/Year 1 and 3 Admissions/Year 1 Admissions.md
@@ -25,7 +25,7 @@ The selection criteria for all Year 1 DSA-Sec applicants to NUS High School will
 | Description |  Dates | Time |
 | Opening of MOE Centralised DSA-Sec Online Portal* | 7 May 2025 | Please refer to MOE website |
 | Closing of MOE Centralised DSA-Sec Online Portal | 3 June 2025 | By 3.00 pm |
-| DSA Selection Tests *(All Applicants)* | 5 July 2025 | 8:30 am - 12:30 pm |
+| DSA Selection Tests *(All Applicants)* | 5 July 2025 | 8:30 am - 12:00 pm |
 | DSA Selection Camp *(Only Shortlisted Applicants)* | 25 or 26 July 2025 | Friday 2.00 pm - 7.00 pm or Saturday 8.00 am - 1.00 pm |
 | Engagement of DSA Exercise *(NUSHS Student for a Day (I) - School Preview) (Only Shortlisted Applicants)* | 8 August 2025 | 1.00 pm - 6.00 pm |
 | Outcome of DSA Exercise | 25 August - 4 September 2025 | By e-mail |

--- a/_students-and-parents/Financial Assistance.md
+++ b/_students-and-parents/Financial Assistance.md
@@ -43,7 +43,5 @@ With effect from 1 April 2019, MOE has introduced the UPLIFT Scholarship to reco
 The UPLIFT Scholarship information is available here: <br>
 <a href="https://www.moe.gov.sg/financial-matters/awards-scholarships/uplift-scholarships">https://www.moe.gov.sg/financial-matters/awards-scholarships/uplift-scholarships</a>
 
-#### **Temasek Foundation Study Award for STEM**
-Temasek Foundation Study Award for STEM may be given to NUS High School students who received school fees subsidy under the tier 1 &amp; 2 MOE Independent School Bursary (ISB) scheme at Tier 1 and Tier 2.
-
-Besides the school fees subsidy under the MOE ISB scheme, NUS High School provides additional financial assistance to needy Singapore Citizen pupils so that all Singaporeans, regardless of their financial background, can benefit from the best opportunities in education.
+#### **NUS High Study Award**
+UPLIFT Scholarship recipents qualify for an additional NUS High Study Award of up to $2,000 per annum, complementing their existing MOE ISB benefits.


### PR DESCRIPTION
1) Removed the following segment on Temasek Foundation Study Award for STEM from the Financial Assistance Website: Financial Assistance and replace with :

NUS High Study Award
UPLIFT Scholarship recipients qualify for an additional NUS High Study Award of up to $2,000 per annum, complementing their existing MOE ISB benefits.

2) Updated DSA Test end time from 12.30 to 12pm
